### PR TITLE
Rename recent connections header (#2364)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,7 @@ DIST_DOCS =			\
 EXTRA_DIST = 			\
 	${DIST_DOCS}		\
 	meson.build		\
+	meson_options.txt	\
 	po/meson.build
 
 MAINTAINERCLEANFILES = 	\

--- a/blueman/main/indicators/StatusNotifierItem.py
+++ b/blueman/main/indicators/StatusNotifierItem.py
@@ -154,8 +154,8 @@ class StatusNotifierItem(IndicatorInterface):
                 "RegisterStatusNotifierItem", GLib.Variant("(s)", ("/org/blueman/sni",)),
                 None, Gio.DBusCallFlags.NONE, -1)
             watcher_expected = True
-        except GLib.Error:
-            watcher_expected = False
+        except GLib.Error as e:
+            watcher_expected = not e.message.startswith("org.freedesktop.DBusError.ServiceUnknown")
             raise IndicatorNotAvailable
 
     def set_icon(self, icon_name: str) -> None:

--- a/blueman/plugins/applet/Menu.py
+++ b/blueman/plugins/applet/Menu.py
@@ -133,6 +133,9 @@ class Menu(AppletPlugin):
         if isinstance(priority, int):
             priority = (priority, 0)
 
+        assert priority[0] < 256
+        assert priority[1] < 256
+
         item = MenuItem(self, owner, priority, text, markup, icon_name, tooltip, callback, submenu_function, visible,
                         sensitive)
         self.__menuitems[item.priority] = item

--- a/blueman/plugins/applet/PulseAudioProfile.py
+++ b/blueman/plugins/applet/PulseAudioProfile.py
@@ -79,7 +79,8 @@ class AudioProfiles(AppletPlugin):
             return items
 
         info = self._devices[device['Address']]
-        menu = self._menu.add(self, (42, info["index"]), _("Audio Profiles for %s") % device.display_name,
+        idx = max((item.priority[1] for item in self._device_menus.values()), default=-1) + 1
+        menu = self._menu.add(self, (42, idx), _("Audio Profiles for %s") % device.display_name,
                               icon_name="audio-card-symbolic",
                               submenu_function=lambda: _generate_profiles_menu(info))
         self._device_menus[device['Address']] = menu

--- a/blueman/plugins/applet/RecentConns.py
+++ b/blueman/plugins/applet/RecentConns.py
@@ -185,7 +185,7 @@ class RecentConns(AppletPlugin, PowerStateListener):
         menu: "Menu" = self.parent.Plugins.Menu
         self._mitems: List[MenuItem] = []
         menu.unregister(self)
-        menu.add(self, 52, text=_("Recent _Connections"), icon_name="document-open-recent-symbolic",
+        menu.add(self, 52, text=_("Reconnect to…"), icon_name="document-open-recent-symbolic",
                  sensitive=False, callback=lambda: None)
         for (idx, item) in enumerate(self.__menuitems):
             self._mitems.append(menu.add(self, (53, idx), **item))

--- a/data/ui/manager-main.ui
+++ b/data/ui/manager-main.ui
@@ -45,6 +45,7 @@
   <object class="GtkApplicationWindow" id="manager_window">
     <property name="can-focus">False</property>
     <property name="icon-name">blueman</property>
+    <property name="title" translatable="yes">Bluetooth Devices</property>
     <child>
       <!-- n-columns=1 n-rows=5 -->
       <object class="GtkGrid" id="grid">

--- a/test/main/Makefile.am
+++ b/test/main/Makefile.am
@@ -4,6 +4,8 @@ SUBDIRS =   \
 
 EXTRA_DIST =    \
     __init__.py \
+    test_dns_server_provider.py \
+    test_dbus_proxies.py \
     test_imports.py \
-    test_dbus_proxies.py    \
+    test_netconf.py \
     test_pulseaudio_utils.py


### PR DESCRIPTION
I hope this makes things clearer and avoids confusion due to the change from 2.3 to 2.4.

Closes #2328